### PR TITLE
Updating optional fields of the returned models

### DIFF
--- a/Github.Api/Models/Account.cs
+++ b/Github.Api/Models/Account.cs
@@ -69,7 +69,7 @@ namespace Github.Api.Models
 		public DateTime UpdatedAt { get; set; }
 
 		[JsonProperty(PropertyName = "type")]
-		public AccountType Type { get; set; }
+		public AccountType? Type { get; set; }
 
 		[JsonProperty(PropertyName = "plan")]
 		public Plan Plan { get; set; }

--- a/Github.Api/Models/Repository.cs
+++ b/Github.Api/Models/Repository.cs
@@ -69,7 +69,7 @@ namespace Github.Api.Models
 		public int OpenIssuesCount { get; set; }
 
 		[JsonProperty(PropertyName = "pushed_at")]
-		public DateTimeOffset PushedAt { get; set; }
+		public DateTimeOffset? PushedAt { get; set; }
 
 		[JsonProperty(PropertyName = "created_at")]
 		public DateTimeOffset CreatedAt { get; set; }

--- a/Github.Api/Models/User.cs
+++ b/Github.Api/Models/User.cs
@@ -39,7 +39,7 @@ namespace Github.Api.Models
 		public bool SiteAdmin { get; set; }
 
 		[JsonProperty(PropertyName = "hireable")]
-		public bool Hireable { get; set; }
+		public bool? Hireable { get; set; }
 
 		[JsonProperty(PropertyName = "bio")]
 		public string Bio { get; set; }


### PR DESCRIPTION
Certain fields of the returned models should be made optional. Trying to deserialize the models from JSON can cause exceptions otherwise. This change is consulted with the Octokit library.

Related: [#301565](http://teampulse.telerik.com/view#item/301565)